### PR TITLE
Add service that return profile info & most played game list

### DIFF
--- a/src/main/java/gg/boardgame/bdgg/BdggApplication.java
+++ b/src/main/java/gg/boardgame/bdgg/BdggApplication.java
@@ -68,7 +68,7 @@ public class BdggApplication implements CommandLineRunner {
 		UserGameHistory gameHistoryOne = UserGameHistory.builder().id(1).count(80).build();
 		gameHistoryOne.changeUser(taehyun);
 		UserGameHistory gameHistoryTwo = UserGameHistory.builder().id(2).count(100).build();
-		gameHistoryTwo.changeUser(jaewon);
+		gameHistoryTwo.changeUser(taehyun);
 
 		userGameHistoryRepository.save(gameHistoryOne);
 		userGameHistoryRepository.save(gameHistoryTwo);

--- a/src/main/java/gg/boardgame/bdgg/BdggApplication.java
+++ b/src/main/java/gg/boardgame/bdgg/BdggApplication.java
@@ -21,7 +21,7 @@ public class BdggApplication implements CommandLineRunner {
 	UserRepository userRepository;
 
 	@Autowired
-	UserGaemHistoryRepository userGameHistoryRepository;
+	UserGameHistoryRepository userGameHistoryRepository;
 
 	@Autowired
 	MatchRepository matchRepository;

--- a/src/main/java/gg/boardgame/bdgg/controller/ProfileController.java
+++ b/src/main/java/gg/boardgame/bdgg/controller/ProfileController.java
@@ -1,5 +1,7 @@
 package gg.boardgame.bdgg.controller;
 
+import gg.boardgame.bdgg.db.User;
+import gg.boardgame.bdgg.dto.GameHistoryDTO;
 import gg.boardgame.bdgg.dto.MatchDTO;
 import gg.boardgame.bdgg.dto.ProfileDTO;
 import gg.boardgame.bdgg.service.ProfileService;
@@ -21,11 +23,12 @@ public class ProfileController {
 
     private final Logger logger = LoggerFactory.getLogger(ProfileController.class);
 
-    @RequestMapping(value = "/{userId}", method = RequestMethod.GET)
-    public @ResponseBody ProfileDTO getProfile(@PathVariable("userId") String userId) {
+    @RequestMapping(path = "/{userId}", method = RequestMethod.GET)
+    public @ResponseBody ProfileDTO getProfile(@PathVariable("userId") Integer userId, Pageable pageable) {
         logger.info(String.format("userId: %s", userId));
+
         // call service
-        return new ProfileDTO();
+        return profileService.getProfile(userId, pageable);
     }
 
     @RequestMapping(path = "/{userId}/matches", method = RequestMethod.GET)

--- a/src/main/java/gg/boardgame/bdgg/db/User.java
+++ b/src/main/java/gg/boardgame/bdgg/db/User.java
@@ -25,8 +25,8 @@ public class User {
     @Column(name = "image_url")
     private String imageUrl;
 
-    @OneToOne(mappedBy = "user")
-    private UserGameHistory gameHistory;
+    @OneToMany(mappedBy = "user")
+    private List<UserGameHistory> gameHistories = new ArrayList<>();
 
     @OneToMany(mappedBy = "user")
     private List<UserMatch> userMatches = new ArrayList<>();

--- a/src/main/java/gg/boardgame/bdgg/db/UserGaemHistoryRepository.java
+++ b/src/main/java/gg/boardgame/bdgg/db/UserGaemHistoryRepository.java
@@ -1,7 +1,0 @@
-package gg.boardgame.bdgg.db;
-
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface UserGaemHistoryRepository extends JpaRepository<UserGameHistory, Long> {
-
-}

--- a/src/main/java/gg/boardgame/bdgg/db/UserGameHistory.java
+++ b/src/main/java/gg/boardgame/bdgg/db/UserGameHistory.java
@@ -14,7 +14,7 @@ public class UserGameHistory {
     @GeneratedValue
     private long id;
 
-    @OneToOne
+    @ManyToOne
     @JoinColumn(name = "user_id")
     private User user;
 
@@ -34,6 +34,6 @@ public class UserGameHistory {
 
     public void changeUser(User user) {
         this.user = user;
-        user.setGameHistory(this);
+        user.getGameHistories().add(this);
     }
 }

--- a/src/main/java/gg/boardgame/bdgg/db/UserGameHistoryRepository.java
+++ b/src/main/java/gg/boardgame/bdgg/db/UserGameHistoryRepository.java
@@ -1,0 +1,10 @@
+package gg.boardgame.bdgg.db;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserGameHistoryRepository extends JpaRepository<UserGameHistory, Long> {
+    public Page<UserGameHistory> findByUser_Id(long userId, Pageable pageable);
+
+}

--- a/src/main/java/gg/boardgame/bdgg/db/UserGameHistoryRepository.java
+++ b/src/main/java/gg/boardgame/bdgg/db/UserGameHistoryRepository.java
@@ -5,6 +5,5 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserGameHistoryRepository extends JpaRepository<UserGameHistory, Long> {
-    public Page<UserGameHistory> findByUser_Id(long userId, Pageable pageable);
-
+     Page<UserGameHistory> findByUser_Id(long userId, Pageable pageable);
 }

--- a/src/main/java/gg/boardgame/bdgg/db/UserMatchRepository.java
+++ b/src/main/java/gg/boardgame/bdgg/db/UserMatchRepository.java
@@ -3,15 +3,12 @@ package gg.boardgame.bdgg.db;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.repository.query.Param;
-
-import java.util.List;
 
 public interface UserMatchRepository extends JpaRepository<UserMatch, Long> {
-    public Page<UserMatch> findByUser_Id(long userId, Pageable pageable);
-    public Page<UserMatch> findByUser_IdAndMatch_GameNo(long userId, int gameNo, Pageable pageable);
-    public Page<UserMatch> findByUser_IdAndMatch_GameType(long userId, int gameType, Pageable pageable);
-    public Page<UserMatch> findByUser_IdAndMatch_GameNoAndMatch_GameType(
+    Page<UserMatch> findByUser_Id(long userId, Pageable pageable);
+    Page<UserMatch> findByUser_IdAndMatch_GameNo(long userId, int gameNo, Pageable pageable);
+    Page<UserMatch> findByUser_IdAndMatch_GameType(long userId, int gameType, Pageable pageable);
+    Page<UserMatch> findByUser_IdAndMatch_GameNoAndMatch_GameType(
             long userId, int gameNo, int gameType, Pageable pageable);
-    public Page<UserMatch> findByMatch_Id(long matchId, Pageable pageable);
+    Page<UserMatch> findByMatch_Id(long matchId, Pageable pageable);
 }

--- a/src/main/java/gg/boardgame/bdgg/db/UserRepository.java
+++ b/src/main/java/gg/boardgame/bdgg/db/UserRepository.java
@@ -6,8 +6,8 @@ import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 
-    public Optional<User> findById(long userId);
-    public Optional<User> findByName(String name);
-    public Optional<User> findByEmail(String email);
+    Optional<User> findById(long userId);
+    Optional<User> findByName(String name);
+    Optional<User> findByEmail(String email);
 
 }

--- a/src/main/java/gg/boardgame/bdgg/db/UserRepository.java
+++ b/src/main/java/gg/boardgame/bdgg/db/UserRepository.java
@@ -6,8 +6,8 @@ import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 
-    Optional<User> findById(Long id);
-    Optional<User> findByName(String name);
-    Optional<User> findByEmail(String email);
+    public Optional<User> findById(long userId);
+    public Optional<User> findByName(String name);
+    public Optional<User> findByEmail(String email);
 
 }

--- a/src/main/java/gg/boardgame/bdgg/dto/ProfileDTO.java
+++ b/src/main/java/gg/boardgame/bdgg/dto/ProfileDTO.java
@@ -1,5 +1,6 @@
 package gg.boardgame.bdgg.dto;
 
+import gg.boardgame.bdgg.db.User;
 import lombok.Data;
 
 import java.util.ArrayList;
@@ -7,8 +8,16 @@ import java.util.List;
 
 @Data
 public class ProfileDTO {
-    private int id;
-    private String Name;
+    private long id;
+    private String name;
+    private String email;
     private String imageUrl;
     private List<GameHistoryDTO> mostPlayed = new ArrayList<>();
+
+    public ProfileDTO(User user) {
+        this.id = user.getId();
+        this.name = user.getName();
+        this.email = user.getEmail();
+        this.imageUrl = user.getImageUrl();
+    }
 }

--- a/src/main/java/gg/boardgame/bdgg/service/ProfileService.java
+++ b/src/main/java/gg/boardgame/bdgg/service/ProfileService.java
@@ -1,10 +1,12 @@
 package gg.boardgame.bdgg.service;
 
 import gg.boardgame.bdgg.dto.MatchDTO;
+import gg.boardgame.bdgg.dto.ProfileDTO;
 import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 
 public interface ProfileService {
+    public ProfileDTO getProfile(Integer userId, Pageable pageable);
     public List<MatchDTO> getMatchList(Integer userId, Integer gameId, Integer gameType, Pageable pageable);
 }

--- a/src/main/java/gg/boardgame/bdgg/service/ProfileService.java
+++ b/src/main/java/gg/boardgame/bdgg/service/ProfileService.java
@@ -7,6 +7,6 @@ import org.springframework.data.domain.Pageable;
 import java.util.List;
 
 public interface ProfileService {
-    public ProfileDTO getProfile(Integer userId, Pageable pageable);
-    public List<MatchDTO> getMatchList(Integer userId, Integer gameId, Integer gameType, Pageable pageable);
+    ProfileDTO getProfile(Integer userId, Pageable pageable);
+    List<MatchDTO> getMatchList(Integer userId, Integer gameId, Integer gameType, Pageable pageable);
 }

--- a/src/main/java/gg/boardgame/bdgg/service/ProfileServiceImpl.java
+++ b/src/main/java/gg/boardgame/bdgg/service/ProfileServiceImpl.java
@@ -1,10 +1,10 @@
 package gg.boardgame.bdgg.service;
 
-import gg.boardgame.bdgg.db.Match;
-import gg.boardgame.bdgg.db.UserMatch;
-import gg.boardgame.bdgg.db.UserMatchRepository;
+import gg.boardgame.bdgg.db.*;
+import gg.boardgame.bdgg.dto.GameHistoryDTO;
 import gg.boardgame.bdgg.dto.IndividualGameResultDTO;
 import gg.boardgame.bdgg.dto.MatchDTO;
+import gg.boardgame.bdgg.dto.ProfileDTO;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -12,11 +12,36 @@ import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 @Service
 public class ProfileServiceImpl implements ProfileService{
     @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private UserGameHistoryRepository userGameHistoryRepository;
+
+    @Autowired
     private UserMatchRepository userMatchRepository;
+
+    @Override
+    public ProfileDTO getProfile(Integer userId, Pageable pageable) {
+
+        Optional<User> user = userRepository.findById(userId);
+        Page<UserGameHistory> userGameHistories = userGameHistoryRepository.findByUser_Id(userId, pageable);
+
+        ProfileDTO profile = new ProfileDTO(user.get());
+
+        userGameHistories.getContent().forEach(u -> {
+            GameHistoryDTO item = new GameHistoryDTO();
+            item.setGameId(u.getGameId());
+            item.setCount(u.getCount());
+            profile.getMostPlayed().add(item);
+        });
+
+        return profile;
+    }
 
     @Override
     public List<MatchDTO> getMatchList(Integer userId, Integer gameId, Integer gameType, Pageable pageable) {


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
- None
## Details
<!-- Detailed description of the change/feature -->
- User & UserGameHistory 연관관계 수정 (1:1 -> 1:N)
- 한 유저가 다수의 game history 정보를 가지도록 test용 db data 생성 로직 수정
- /profiles/{user-id} 로 GET API 요청시 해당 user-id에 매칭되는 프로필
정보와 가장 많이 플레이한 게임 히스토리 정보를 리턴하는 API 추가